### PR TITLE
Suppress expected fpp generator errors

### DIFF
--- a/rspecFppGen/name_visitor.py
+++ b/rspecFppGen/name_visitor.py
@@ -103,7 +103,7 @@ def generate_server(setup_code: str, answer_code: str, *,
         Bcolors.warn('SyntaxError: Could not extract exports from answer')
         answer_names = []
 
-    if not setup_names: and not answer_names:
+    if not setup_names and not answer_names:
         return (SERVER_DEFAULT, [], [])
 
     def format_annotated_name(name: AnnotatedName) -> str:


### PR DESCRIPTION
Avoid parsing the test suite as Python code to prevent showing the instructor an unwarranted error message